### PR TITLE
feat: add HTB cheatsheets MkDocs site

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,17 @@
+name: gh-pages
+on:
+  push:
+    branches: [ main ]
+permissions:
+  contents: write
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - run: pip install -r requirements.txt
+      - run: python scripts/sync.py
+      - run: mkdocs gh-deploy --force

--- a/README.md
+++ b/README.md
@@ -1,1 +1,36 @@
-# CDSA
+# HTB Cheatsheets
+
+Projet de cheatsheets Hack The Box construit avec MkDocs Material.
+
+## Installation
+
+```bash
+pip install -r requirements.txt
+python scripts/sync.py
+mkdocs serve
+```
+
+## Front matter
+
+Chaque fiche commence par un bloc YAML :
+
+```yaml
+---
+title: Kerberoasting
+tags: [AD, hash, spn]
+os: [Windows]
+difficulty: Intermediate
+---
+```
+
+- **tags** : mots-clés (AD, Web, privesc…)
+- **os** : systèmes concernés
+- **difficulty** : Beginner, Intermediate, Advanced
+
+## Déploiement
+
+Le site est publié automatiquement sur GitHub Pages via `gh-pages` :
+
+```bash
+git push origin main
+```

--- a/cheatsheets/Active_Directory/kerberoasting.md
+++ b/cheatsheets/Active_Directory/kerberoasting.md
@@ -1,0 +1,24 @@
+---
+title: Kerberoasting
+tags: [AD, hash, spn]
+os: [Windows]
+difficulty: Intermediate
+---
+
+Kerberoasting permet d'extraire des hash de service pour des attaques offline.
+
+!!! tip "Astuce"
+    Vérifie que l'horloge est synchronisée avec le contrôleur de domaine.
+
+=== "bash"
+    ```bash
+    GetUserSPNs.py -request -dc-ip {{ target_ip }} {{ domain }}/user:password
+    ```
+
+=== "pwsh"
+    ```pwsh
+    Invoke-Kerberoast -Domain {{ domain }} -OutputFormat Hashcat
+    ```
+
+!!! opsec "OPSEC"
+    Évite de déclencher des alertes en limitant le nombre de requêtes.

--- a/cheatsheets/Privesc/windows_privesc.md
+++ b/cheatsheets/Privesc/windows_privesc.md
@@ -1,0 +1,24 @@
+---
+title: Windows Privilege Escalation
+tags: [privesc, windows]
+os: [Windows]
+difficulty: Advanced
+---
+
+Escalade de privilèges sous Windows.
+
+!!! info
+    Utilise `winPEAS.exe` pour l'énumération.
+
+=== "pwsh"
+    ```pwsh
+    .\winPEAS.exe
+    ```
+
+=== "bash"
+    ```bash
+    smbclient \\{{ target_ip }}\C$ -U {{ domain }}\\user
+    ```
+
+!!! danger
+    Les modifications du registre peuvent rendre le système instable.

--- a/cheatsheets/Web/sql_injection.md
+++ b/cheatsheets/Web/sql_injection.md
@@ -1,0 +1,25 @@
+---
+title: SQL Injection
+tags: [Web, SQLi]
+os: [Linux]
+difficulty: Beginner
+---
+
+Les injections SQL permettent de manipuler la base de données.
+
+!!! warning
+    Toujours tester les paramètres GET et POST.
+
+=== "bash"
+    ```bash
+    sqlmap -u "http://{{ target_ip }}/index.php?id=1" --batch
+    ```
+
+=== "python"
+    ```python
+    import requests
+    requests.get(f"http://{{ target_ip }}/index.php?id=1'-- -")
+    ```
+
+!!! ttp "TTP"
+    Documente chaque payload utilisé.

--- a/cheatsheets/index.md
+++ b/cheatsheets/index.md
@@ -1,0 +1,4 @@
+---
+title: Hack The Box Cheatsheets
+---
+<div id="cards" class="masonry" aria-label="Cheatsheets"></div>

--- a/docs
+++ b/docs
@@ -1,0 +1,1 @@
+cheatsheets

--- a/main.py
+++ b/main.py
@@ -1,0 +1,11 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).parent / 'scripts'))
+from sync import Sync
+
+def define_env(env):
+    sync = Sync()
+    nav, cards = sync.build()
+    sync.write_nav(nav)
+    sync.write_cards(cards)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,60 @@
+site_name: HTB Cheatsheets
+site_url: https://example.com
+repo_url: https://github.com/example/htb-cheats
+docs_dir: docs
+use_directory_urls: true
+theme:
+  name: material
+  language: en
+  font:
+    text: Inter
+    code: JetBrains Mono
+  palette:
+  - scheme: slate
+    primary: blue grey
+    accent: cyan
+    toggle:
+      icon: material/weather-sunny
+      name: Switch to light mode
+  - scheme: default
+    primary: grey
+    accent: emerald
+    toggle:
+      icon: material/weather-night
+      name: Switch to dark mode
+  features:
+  - navigation.tabs
+  - navigation.sections
+  - search.highlight
+  - search.suggest
+  - content.tabs.link
+  - content.code.copy
+extra_css:
+- overrides/assets/styles.css
+extra_javascript:
+- overrides/assets/app.js
+plugins:
+- search
+- macros
+- git-revision-date-localized:
+    fallback_to_build_date: true
+- glightbox
+markdown_extensions:
+- admonition
+- pymdownx.superfences
+- pymdownx.tabbed:
+    alternate_style: true
+- pymdownx.highlight
+- pymdownx.inlinehilite
+- toc:
+    permalink: true
+extra:
+  target_ip: 10.10.10.10
+  domain: example.htb
+nav:
+- Active Directory:
+  - Kerberoasting: Active_Directory/kerberoasting.md
+- Privesc:
+  - Windows Privilege Escalation: Privesc/windows_privesc.md
+- Web:
+  - SQL Injection: Web/sql_injection.md

--- a/overrides/assets/app.js
+++ b/overrides/assets/app.js
@@ -1,0 +1,61 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const search = document.querySelector('input[data-md-component="search-query"]');
+  document.addEventListener('keydown', (e) => {
+    if (e.key === '/' && document.activeElement !== search) {
+      e.preventDefault();
+      search.focus();
+    }
+    if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
+      e.preventDefault();
+      search.focus();
+    }
+  });
+
+  const copyBtn = document.createElement('button');
+  copyBtn.id = 'copy-all';
+  copyBtn.textContent = 'Copy all commands';
+  copyBtn.addEventListener('click', () => {
+    const blocks = Array.from(document.querySelectorAll('pre code'));
+    const text = blocks.map(b => b.innerText).join('\n');
+    navigator.clipboard.writeText(text);
+  });
+  const content = document.querySelector('.md-content');
+  if (content) content.prepend(copyBtn);
+
+  fetch('/overrides/assets/cards.json')
+    .then(r => r.json())
+    .then(data => renderCards(data));
+
+  function renderCards(cards){
+    const container = document.getElementById('cards');
+    if(!container) return;
+    container.innerHTML = '';
+    cards.forEach(card => {
+      const div = document.createElement('div');
+      div.className = 'card';
+      div.innerHTML = `
+        <h3><a href='/${card.path}'>${card.title}</a></h3>
+        <div class="meta">
+          ${card.difficulty ? `<span class='badge difficulty'>${card.difficulty}</span>` : ''}
+          ${card.os.map(o=>`<span class='badge os'>${o}</span>`).join('')}
+          ${card.tags.map(t=>`<span class='badge tag' data-tag='${t}'>${t}</span>`).join('')}
+        </div>
+        <small>${card.last_updated}</small>
+        <div class='actions'>
+          <a class='md-button' href='/${card.path}'>Open</a>
+          <button class='md-button copy-card' data-path='/${card.path}'>Copy all</button>
+        </div>`;
+      container.appendChild(div);
+    });
+    container.querySelectorAll('[data-tag]').forEach(el=>{
+      el.addEventListener('click', ()=>filterTag(el.dataset.tag));
+    });
+  }
+
+  function filterTag(tag){
+    const cards = document.querySelectorAll('#cards .card');
+    cards.forEach(c=>{
+      c.style.display = c.querySelector(`[data-tag='${tag}']`) ? '' : 'none';
+    });
+  }
+});

--- a/overrides/assets/cards.json
+++ b/overrides/assets/cards.json
@@ -1,0 +1,42 @@
+[
+  {
+    "title": "Kerberoasting",
+    "path": "Active_Directory/kerberoasting/",
+    "tags": [
+      "AD",
+      "hash",
+      "spn"
+    ],
+    "os": [
+      "Windows"
+    ],
+    "difficulty": "Intermediate",
+    "last_updated": ""
+  },
+  {
+    "title": "Windows Privilege Escalation",
+    "path": "Privesc/windows_privesc/",
+    "tags": [
+      "privesc",
+      "windows"
+    ],
+    "os": [
+      "Windows"
+    ],
+    "difficulty": "Advanced",
+    "last_updated": ""
+  },
+  {
+    "title": "SQL Injection",
+    "path": "Web/sql_injection/",
+    "tags": [
+      "Web",
+      "SQLi"
+    ],
+    "os": [
+      "Linux"
+    ],
+    "difficulty": "Beginner",
+    "last_updated": ""
+  }
+]

--- a/overrides/assets/manifest.webmanifest
+++ b/overrides/assets/manifest.webmanifest
@@ -1,0 +1,8 @@
+{
+  "name": "HTB Cheatsheets",
+  "short_name": "HTB Cheats",
+  "start_url": ".",
+  "display": "standalone",
+  "background_color": "#1f1f1f",
+  "description": "Offline Hack The Box cheatsheets"
+}

--- a/overrides/assets/styles.css
+++ b/overrides/assets/styles.css
@@ -1,0 +1,10 @@
+.meta-badges { margin-bottom: 1rem; }
+.badge { display:inline-block; padding:0.2rem 0.5rem; margin-right:0.2rem; border-radius:4px; font-size:0.75rem; }
+.badge.difficulty { background:#00acc1; color:#fff; }
+.badge.tag { background:#37474f; color:#fff; cursor:pointer; }
+.badge.os { background:#2e7d32; color:#fff; }
+.masonry { column-count:3; column-gap:1rem; }
+.masonry .card { break-inside: avoid; background:rgba(255,255,255,0.05); padding:1rem; margin:0 0 1rem; border-radius:8px; backdrop-filter:blur(10px); }
+@media (max-width:800px){ .masonry { column-count:1; } }
+.md-nav--secondary { position:sticky; top:4.8rem; }
+#copy-all { margin-bottom:1rem; }

--- a/overrides/assets/sw.js
+++ b/overrides/assets/sw.js
@@ -1,0 +1,2 @@
+self.addEventListener('install', () => self.skipWaiting());
+self.addEventListener('fetch', () => {});

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -1,0 +1,17 @@
+{% extends "base.html" %}
+
+{% block content %}
+  {% if page.meta.tags or page.meta.os or page.meta.difficulty %}
+  <div class="meta-badges">
+    {% if page.meta.difficulty %}<span class="badge difficulty">{{ page.meta.difficulty }}</span>{% endif %}
+    {% for t in page.meta.tags %}<span class="badge tag">{{ t }}</span>{% endfor %}
+    {% for o in page.meta.os %}<span class="badge os">{{ o }}</span>{% endfor %}
+  </div>
+  {% endif %}
+  {{ super() }}
+{% endblock %}
+
+{% block scripts %}
+  {{ super() }}
+  <script src="{{ '/overrides/assets/app.js' | url }}"></script>
+{% endblock %}

--- a/overrides/partials/card-list.html
+++ b/overrides/partials/card-list.html
@@ -1,0 +1,1 @@
+<div id="cards" class="masonry" aria-label="Cheatsheets"></div>

--- a/overrides/partials/search.html
+++ b/overrides/partials/search.html
@@ -1,0 +1,5 @@
+<div class="md-search" data-md-component="search" role="dialog">
+  <label class="md-search__form" for="search">
+    <input id="search" type="text" class="md-search__input" placeholder="Search (Ctrl/Cmd + K)" data-md-component="search-query" />
+  </label>
+</div>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+mkdocs-material
+mkdocs-glightbox
+mkdocs-macros-plugin
+mkdocs-git-revision-date-localized-plugin
+pyyaml

--- a/scripts/sync.py
+++ b/scripts/sync.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+import json
+import subprocess
+from pathlib import Path
+
+import yaml
+from mkdocs.plugins import BasePlugin
+from mkdocs.config import config_options
+
+class Plugin(BasePlugin):
+    config_scheme = (
+        ('cheatsheets_dir', config_options.Type(str, default='cheatsheets')),
+    )
+
+    def on_pre_build(self, config):
+        sync = Sync(Path(self.config['cheatsheets_dir']))
+        nav, cards = sync.build()
+        config['nav'] = nav
+        sync.write_nav(nav)
+        sync.write_cards(cards)
+        return config
+
+class Sync:
+    def __init__(self, cheatsheets_dir=Path('cheatsheets')):
+        self.cheatsheets_dir = Path(cheatsheets_dir)
+        self.mkdocs_file = Path('mkdocs.yml')
+        self.cards_file = Path('overrides/assets/cards.json')
+
+    def build(self):
+        nav = []
+        cards = []
+        for section in sorted([p for p in self.cheatsheets_dir.iterdir() if p.is_dir()]):
+            items = []
+            for md in sorted(section.glob('*.md')):
+                if md.name == 'index.md':
+                    continue
+                meta = self.read_meta(md)
+                title = meta.get('title', md.stem.replace('_', ' ').title())
+                rel_path = md.relative_to(self.cheatsheets_dir).as_posix()
+                items.append({title: rel_path})
+                last = self.git_date(md)
+                cards.append({
+                    'title': title,
+                    'path': rel_path.replace('.md', '/'),
+                    'tags': meta.get('tags', []),
+                    'os': meta.get('os', []),
+                    'difficulty': meta.get('difficulty', ''),
+                    'last_updated': last
+                })
+            if items:
+                nav.append({section.name.replace('_', ' '): items})
+        return nav, cards
+
+    def read_meta(self, path: Path):
+        text = path.read_text(encoding='utf-8')
+        if text.startswith('---'):
+            try:
+                _, fm, _ = text.split('---', 2)
+                return yaml.safe_load(fm) or {}
+            except ValueError:
+                return {}
+        return {}
+
+    def git_date(self, path: Path) -> str:
+        try:
+            result = subprocess.run(
+                ['git', 'log', '-1', '--format=%cs', str(path)],
+                capture_output=True, text=True, check=True
+            )
+            return result.stdout.strip()
+        except subprocess.CalledProcessError:
+            return ''
+
+    def write_nav(self, nav):
+        config = yaml.safe_load(self.mkdocs_file.read_text(encoding='utf-8'))
+        config['nav'] = nav
+        self.mkdocs_file.write_text(yaml.safe_dump(config, sort_keys=False), encoding='utf-8')
+
+    def write_cards(self, cards):
+        self.cards_file.parent.mkdir(parents=True, exist_ok=True)
+        self.cards_file.write_text(json.dumps(cards, indent=2), encoding='utf-8')
+
+if __name__ == '__main__':
+    sync = Sync()
+    nav, cards = sync.build()
+    sync.write_nav(nav)
+    sync.write_cards(cards)


### PR DESCRIPTION
## Summary
- scaffold MkDocs Material site with dark/light palettes, tag badges, and custom cards UI
- add sample Hack The Box cheatsheets and automation to build navigation/cards
- configure GitHub Actions for deployment

## Testing
- `pip install -r requirements.txt`
- `python scripts/sync.py`
- `mkdocs build`

------
https://chatgpt.com/codex/tasks/task_e_689a10d310288329ae6514c12133421d